### PR TITLE
Startup script improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ define Package/shairport-sync/default/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/scripts/shairport-sync.conf $(1)/etc/shairport-sync.conf
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/shairport-sync.init $(1)/etc/init.d/shairport-sync
+	$(INSTALL_BIN) ./files/netwait.init $(1)/etc/init.d/netwait
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./files/shairport-sync.config $(1)/etc/config/shairport-sync
 endef

--- a/files/netwait.init
+++ b/files/netwait.init
@@ -1,0 +1,24 @@
+#!/bin/sh /etc/rc.common
+
+START=21
+
+wait_for_ifaces() {
+  logger -t netwait "NetWait service: Checking if network interfaces are up ..."
+  local lan_up=`uci -p /var/state  get network.lan.up`
+  local loopback_up=`uci -p /var/state  get network.loopback.up`
+  while [ "$lan_up" != 1 -o "$loopback_up" != 1 ] ; do
+    logger -t netwait "NetWait service: Network interfaces not yet up, waiting ..."
+    sleep 2s
+    lan_up=`uci -p /var/state  get network.lan.up`
+    loopback_up=`uci -p /var/state  get network.loopback.up`
+  done;
+  logger -t netwait "NetWait service: Interfaces UP. Continue service startup."
+}
+
+start() {
+        wait_for_ifaces
+}
+
+stop() {
+        return
+}

--- a/files/shairport-sync.init
+++ b/files/shairport-sync.init
@@ -130,6 +130,13 @@ service_triggers() {
 }
 
 start_service() {
+	local mdns_backend=$(uci show shairport-sync.shairport_sync.mdns_backend);
+	if [ "$(expr match "$mdns_backend" '.*=\(.*\)')" == "'tinysvcmdns'" ]; then
+		route | grep 224 > /dev/null
+		if [ $? -eq 1 ]; then
+			route add -net 224.0.0.0 netmask 224.0.0.0 wlan0
+		fi    
+	fi  
 	config_load shairport-sync
 	config_foreach start_instance shairport-sync
 }


### PR DESCRIPTION
Add netwait script to wait for network interfaces before starting shairport [(OpenWrt ticket #19427)](https://dev.openwrt.org/ticket/19427)
Automatically add multicast route to wlan interface if embedded mdns is configured
